### PR TITLE
Add a few fixes and improvements

### DIFF
--- a/src/comptime_impl.rs
+++ b/src/comptime_impl.rs
@@ -202,7 +202,7 @@ fn merge_externs(deps_dir: &Path, args: &[String]) -> Vec<String> {
     let mut merged_externs = Vec::with_capacity(cargo_rlibs.len() * 2);
     for (lib_name, path) in cargo_rlibs.iter() {
         merged_externs.push("--extern".to_string());
-        merged_externs.push(format!("{}={}", &lib_name["lib".len()..], path.display()));
+        merged_externs.push(format!("{}={}", &lib_name.strip_prefix("lib").unwrap_or(lib_name), path.display()));
     }
 
     merged_externs

--- a/src/comptime_impl.rs
+++ b/src/comptime_impl.rs
@@ -124,7 +124,7 @@ pub fn comptime_impl(_args: TokenStream, input: TokenStream) -> TokenStream {
     quote!(
         #(#attrs)*
         #vis #sig {
-            #(#result)*
+            #result
         }
     )
     .into()

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,0 +1,9 @@
+#[test]
+fn it_adds() {
+    assert_eq!(adder(), 2);
+}
+
+#[comptime::comptime]
+fn adder() -> i32 {
+    1 + 1
+}


### PR DESCRIPTION
One useful improvement that I did not add is to create the temporary files inside of a tempdir so that they are deleted if the proc macro panics. Alternatively, remove all unwraps/panics, return errors, and then catch and cleanup.